### PR TITLE
CSSの分離

### DIFF
--- a/todo-react/src/components/CompleteTodo.jsx
+++ b/todo-react/src/components/CompleteTodo.jsx
@@ -1,9 +1,18 @@
 import React from "react";
 
+const styles = {
+  backgroundColor: '#ffffe0',
+  width: '400px',
+  minHeight: '200px',
+  padding: '8px',
+  margin: '8px',
+  borderRadius: '8px'
+};
+
 export const CompleteTodo = (props) => {
   const { completeTodos, onClickBack } = props;
   return (
-    <div className="complete-area">
+    <div style={styles}>
     <p className="title">完了のTODO</p>
       <ul>
         {completeTodos.map((todo, index) => {

--- a/todo-react/src/components/IncompleteTodo.jsx
+++ b/todo-react/src/components/IncompleteTodo.jsx
@@ -1,9 +1,18 @@
 import React from "react";
 
+const styles = {
+  backgroundColor: '#c6ffe2',
+  width: '400px',
+  minHeight: '200px',
+  padding: '8px',
+  margin: '8px',
+  borderRadius: '8px'
+}
+
 export const IncompleteTodo = (props) => {
   const { incompleteTodos, onClickComplete, onClickDelete } = props;
   return (
-    <div className="incomplete-area">
+    <div style={styles}>
       <p className="title">未完了のTODO</p>
       <ul>
         {incompleteTodos.map((todo, index) => {

--- a/todo-react/src/components/InputTodo.jsx
+++ b/todo-react/src/components/InputTodo.jsx
@@ -1,9 +1,17 @@
 import React from "react";
 
+const styles = {
+  backgroundColor: '#c1ffff',
+  width: '400px',
+  height: '30px',
+  padding: '8px',
+  margin: '8px',
+  borderRadius: '8px'
+};
 export const InputTodo = (props) => {
   const {todoText, onChange, onClick} = props;
   return (
-    <div className="input-area">
+    <div style={styles}>
       <input placeholder="TODOを入力" value = {todoText} onChange={onChange} />
       <button onClick={onClick}>追加</button>
     </div>

--- a/todo-react/src/index.css
+++ b/todo-react/src/index.css
@@ -21,31 +21,6 @@ button:hover {
 li {
   margin-right: 8px;
 }
-
-.input-area {
-  background-color: #c1ffff;
-  width: 400px;
-  height: 30px;
-  padding: 8px;
-  margin: 8px;
-  border-radius: 8px;
-}
-.incomplete-area {
-  background-color: #c6ffe2;
-  width: 400px;
-  min-height: 200px;
-  padding: 8px;
-  margin: 8px;
-  border-radius: 8px;
-}
-.complete-area {
-  background-color: #ffffe0;
-  width: 400px;
-  min-height: 200px;
-  padding: 8px;
-  margin: 8px;
-  border-radius: 8px;
-}
 .title {
   text-align: center;
   margin-top: 0px;


### PR DESCRIPTION
CSSファイルに全てのレイアウトを記述するのではなく、コンポーネントごとにCSSを定義することで関心の分離を行った。
コンポーネントファイルごとにそれぞれ定義してあるため、どのファイルにどのCSSを当てているのかがわかりやすくなった。